### PR TITLE
Add parent parameter to issue resource

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -44,3 +44,17 @@ resource "jira_issue" "example" {
   project_key = "PROJ"
 }
 
+resource "jira_issue" "example_subtask" {
+  assignee = "anubhavmishra"
+  reporter = "anubhavmishra"
+
+  issue_type = "Sub-task"
+
+  // description is optional
+  description = "This is a test subtask"
+  summary     = "Subtask Summary"
+
+  project_key = "PROJ"
+  parent      = jira_issue.example.issue_key
+}
+

--- a/jira/resource_issue.go
+++ b/jira/resource_issue.go
@@ -67,6 +67,11 @@ func resourceIssue() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"parent": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"state": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -99,6 +104,7 @@ func resourceIssueCreate(d *schema.ResourceData, m interface{}) error {
 	config := m.(*Config)
 	assignee := d.Get("assignee")
 	reporter := d.Get("reporter")
+	parent := d.Get("parent")
 	fields := d.Get("fields")
 	issueType := d.Get("issue_type").(string)
 	description := d.Get("description").(string)
@@ -128,6 +134,12 @@ func resourceIssueCreate(d *schema.ResourceData, m interface{}) error {
 	if reporter != "" {
 		i.Fields.Reporter = &jira.User{
 			Name: reporter.(string),
+		}
+	}
+
+	if parent != "" {
+		i.Fields.Parent = &jira.Parent{
+			ID: parent.(string),
 		}
 	}
 
@@ -191,6 +203,10 @@ func resourceIssueRead(d *schema.ResourceData, m interface{}) error {
 
 	if issue.Fields.Reporter != nil {
 		d.Set("reporter", issue.Fields.Reporter.Name)
+	}
+
+	if issue.Fields.Parent != nil {
+		d.Set("parent", issue.Fields.Parent.Key)
 	}
 
 	// Custom or non-standard fields


### PR DESCRIPTION
We plan on creating subtasks from within Terraform, but this requires the parent field to be set on the issue. The current provider as it was did not support this, as the parent field is of object type and the custom fields implementation only works as a string map.

The parameter is optional (as it isn't required for normal issues), but forces recreation if changed (because the REST API does not support moving subtasks between parent issues yet).

We tested this successfully against our on-premise JIRA 8.13.5 with Terraform v0.14 and v0.15.