### PR TITLE
Adds "data." to examples to prevent syntax errors

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -38,7 +38,7 @@ resource "jira_issue" "example" {
   summary     = "Created using Terraform"
   labels      = ["label1", "label2"]
   fields      = {
-    (jira_field.epic_link.id) = jira_issue.example_epic.issue_key
+    (data.jira_field.epic_link.id) = jira_issue.example_epic.issue_key
   }
 
   project_key = "PROJ"


### PR DESCRIPTION
This is a simple change to fix syntax in the provided example.

The previous value for 'fields' was "jira_field.epic_link.id", adding "data." first should make this example function.