### PR TITLE
Added error parsing to cause project recreation on 404

### DIFF
--- a/jira/resource_project.go
+++ b/jira/resource_project.go
@@ -3,7 +3,7 @@ package jira
 import (
 	"fmt"
 	"strconv"
-
+	"strings"
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/pkg/errors"
@@ -231,8 +231,16 @@ func resourceProjectRead(d *schema.ResourceData, m interface{}) error {
 
 	urlStr := fmt.Sprintf("%s/%s", projectAPIEndpoint, d.Id())
 	err := request(config.jiraClient, "GET", urlStr, nil, project)
+
 	if err != nil {
+		errMessage := err.Error()
+		if strings.Contains(errMessage, "Status code: 404") {
+			d.SetId("")
+			return nil
+		}
 		return errors.Wrap(err, "Request failed")
+		d.SetId("")
+		return nil
 	}
 
 	if err != nil {

--- a/jira/resource_project.go
+++ b/jira/resource_project.go
@@ -3,7 +3,7 @@ package jira
 import (
 	"fmt"
 	"strconv"
-	"strings"
+
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/pkg/errors"
@@ -45,7 +45,7 @@ type ProjectRequest struct {
 	IssueSecurityScheme int    `json:"issueSecurityScheme,omitempty" structs:"issueSecurityScheme,omitempty"`
 	PermissionScheme    int    `json:"permissionScheme,omitempty" structs:"permissionScheme,omitempty"`
 	NotificationScheme  int    `json:"notificationScheme,omitempty" structs:"notificationScheme,omitempty"`
-	CategoryID          string    `json:"categoryId,omitempty" structs:"categoryId,omitempty"`
+	CategoryID          string `json:"categoryId,omitempty" structs:"categoryId,omitempty"`
 }
 
 type SharedConfigurationProjectResponse struct {
@@ -233,14 +233,11 @@ func resourceProjectRead(d *schema.ResourceData, m interface{}) error {
 	err := request(config.jiraClient, "GET", urlStr, nil, project)
 
 	if err != nil {
-		errMessage := err.Error()
-		if strings.Contains(errMessage, "Status code: 404") {
+		if errors.Is(err, ResourceNotFoundError) {
 			d.SetId("")
 			return nil
 		}
 		return errors.Wrap(err, "Request failed")
-		d.SetId("")
-		return nil
 	}
 
 	if err != nil {

--- a/jira/resource_project_test.go
+++ b/jira/resource_project_test.go
@@ -39,6 +39,31 @@ func TestAccJiraProject_basic(t *testing.T) {
 	})
 }
 
+func TestAccJiraProject_deleted(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckJiraProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJiraProjectConfig(rInt),
+			},
+			{
+				PreConfig: func() {
+					urlStr := fmt.Sprintf("%s/PX%d", projectAPIEndpoint, rInt%100000)
+					jiraClient := testAccProvider.Meta().(*Config).jiraClient
+					err := request(jiraClient, "DELETE", urlStr, nil, nil)
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config: testAccJiraProjectConfig(rInt),
+			},
+		},
+	})
+}
+
 func TestAccJiraProject_shared(t *testing.T) {
 	rInt := acctest.RandInt()
 
@@ -109,7 +134,7 @@ resource "jira_user" "foo" {
 }
 
 resource "jira_project_category" "category" {
-	name = "Managed"
+	name = "Managed %d"
   	description = "Managed Projects"
 }
 
@@ -120,7 +145,7 @@ resource "jira_project" "foo" {
   project_type_key = "business"
   project_template_key = "com.atlassian.jira-core-project-templates:jira-core-project-management"
   category_id = "${jira_project_category.category.id}"
-}`, rInt, rInt, rInt%100000)
+}`, rInt, rInt, rInt, rInt%100000)
 }
 
 func testAccJiraProjectConfigUpdate(rInt int) string {
@@ -132,7 +157,7 @@ resource "jira_user" "foo" {
 }
 
 resource "jira_project_category" "category" {
-	name = "Managed"
+	name = "Managed %d"
   	description = "Managed Projects"
 }
 
@@ -143,7 +168,7 @@ resource "jira_project" "foo" {
   project_type_key = "software"
   project_template_key = "com.atlassian.jira-core-project-templates:jira-core-project-management"
   category_id = "${jira_project_category.category.id}"
-}`, rInt, rInt, rInt%100000)
+}`, rInt, rInt, rInt, rInt%100000)
 }
 
 func testAccJiraSharedProjectConfig(rInt int) string {


### PR DESCRIPTION
I am not a big fan of string parsing for error handling, but this was the best way I could resolve issue #68 without changing the client as I understand it.

This change parses for 404s on project reads. If a 404 is returned, the project ID will be set to an empty string triggering a project recreation and a message from Terraform notifying of the change made outside of Terraform.

If this change is okay, I believe it also needs to be added to the update method and potentially all the other resources as I do not see 404 handling. 