### PR TITLE
Terraform validate breaks when no user or token is supplied

### DIFF
--- a/jira/provider.go
+++ b/jira/provider.go
@@ -17,8 +17,6 @@ func Provider() *schema.Provider {
 			},
 			"user": {
 				Type:         schema.TypeString,
-				ExactlyOneOf: []string{"token"},
-				RequiredWith: []string{"password"},
 				Optional:     true,
 				DefaultFunc:  schema.EnvDefaultFunc("JIRA_USER", nil),
 				Description:  "Username for your user. Can be specified with the JIRA_USER environment variable.",


### PR DESCRIPTION
This PR will set the credentials to be optional to be able to run `terraform validate` without providing any credentials i.e. in CI/CD pipelines.

This will fix issue #85