### PR TITLE
Implement the ability to update the projects sender email-address

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -3,7 +3,7 @@
 page_title: "jira_project Resource - terraform-provider-jira"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # jira_project (Resource)
@@ -64,10 +64,9 @@ resource "jira_project" "project_shared" {
 - `project_type_key` (String)
 - `shared_configuration_project_id` (Number)
 - `url` (String)
+- `email` (String) The project's sender email. [Note that it must be setup by an admin](https://support.atlassian.com/organization-administration/docs/add-custom-email-addresses-for-product-notifications/). If the value is empty it will default to the tenant default.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `project_id` (Number)
-
-


### PR DESCRIPTION
This PR implements the ability to set the projects sender email-address. [Note that an admin must first set it up](https://support.atlassian.com/organization-administration/docs/add-custom-email-addresses-for-product-notifications/) and afterwards it is possibly to change the sender for each project.

As stated in the docs, an empty value( or a delete-ish operation) will revert it back to the tenant-provided email. E.g. `jira @ jira-tenant . atlassian . net`.