### PR TITLE
Use accountId instead of deprecated username to handle group membership

### DIFF
--- a/jira/resource_group_membership.go
+++ b/jira/resource_group_membership.go
@@ -12,7 +12,7 @@ import (
 
 // GroupMembership The struct sent to the JIRA instance to create a new GroupMembership
 type GroupMembership struct {
-	AccountId string `json:"name,omitempty" structs:"name,omitempty"`
+	AccountId string `json:"accountId,omitempty" structs:"accountId,omitempty"`
 }
 
 // Group

--- a/jira/resource_group_membership.go
+++ b/jira/resource_group_membership.go
@@ -105,9 +105,9 @@ func resourceGroupMembershipCreate(d *schema.ResourceData, m interface{}) error 
 func resourceGroupMembershipRead(d *schema.ResourceData, m interface{}) error {
 	config := m.(*Config)
 
-	components := strings.SplitN(d.Id(), ":", 2)
-	accountId := components[0]
-	groupname := components[1]
+	separatorIndex := strings.LastIndex(d.Id(), ":")
+	accountId := d.Id()[:separatorIndex]
+	groupname := d.Id()[separatorIndex+1:]
 
 	groups, _, err := getGroups(config.jiraClient, accountId)
 	if err != nil {


### PR DESCRIPTION
Fix #47 

More information regarding deprecation : https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/